### PR TITLE
Add QnA question voting for students

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -21,11 +21,21 @@
       ".write": "auth != null && root.child('users').child(auth.uid).child('status').val() == 'staff'",
       "$githubName": {
         ".read":  "auth != null && root.child('users').child(auth.uid).child('gitHubName').val() == $githubName",
-        ".write": "auth != null && root.child('users').child(auth.uid).child('gitHubName').val() == $githubName"
+        ".write": "auth != null && root.child('users').child(auth.uid).child('gitHubName').val() == $githubName",
+        "$questionName": {
+          ".read":  "auth != null && root.child('questions').child(root.child('users').child(auth.uid).child('gitHubName').val()).val() != null && root.child('questions').child(root.child('users').child(auth.uid).child('gitHubName').val()).child($questionName).val() != null && root.child('questions').child(root.child('users').child(auth.uid).child('gitHubName').val()).child($questionName).hasChildren()",
+          "$questionIndex": {
+            "upVoters" : {
+              "$upVoter": {
+                ".write": "auth != null && root.child('users').child(auth.uid).child('gitHubName').val() == $upVoter"
+              }
+            }
+          }
+        }
       }
     },
     "users": {
-      ".read":  "auth != null && root.child('users').child(auth.uid).child('status').val() == 'staff'",
+      ".read":  "auth != null",
       ".write": "auth != null && root.child('users').child(auth.uid).child('status').val() == 'staff'",
       "$uid": {
         ".read":  "auth != null && auth.uid == $uid",

--- a/html/css/ejs.css
+++ b/html/css/ejs.css
@@ -1014,6 +1014,9 @@ sup {
   background-color: rgb(185, 203, 179);
 }
 
+.voting-section.hidden{
+  display: none;
+}
 
 .vote-up {
   cursor: pointer;

--- a/html/css/ejs.css
+++ b/html/css/ejs.css
@@ -1008,3 +1008,13 @@ sup {
     color: black;
     font-size: 70%;
 }
+
+.dwa-qna .voting-section {
+  border-color: rgb(76, 144, 71);
+  background-color: rgb(185, 203, 179);
+}
+
+
+.vote-up {
+  cursor: pointer;
+}

--- a/html/js/dwa-additions.js
+++ b/html/js/dwa-additions.js
@@ -536,7 +536,6 @@ class QnAForm {  // similar to LongExercise, but having multiple fields
       this.storeQnAToDB();
     } else {
       this.createVotingLink();
-      this.showVotingLinkWhenAvailable();
       this.createFormUI();
       this.setupFirebaseSubscription();
     }
@@ -591,6 +590,7 @@ class QnAForm {  // similar to LongExercise, but having multiple fields
     this.mde[questionNr].codemirror.on("change", (codemirrorInstance, changeObj) => {
       // console.log("MDE ON CHANGE", changeObj);
       if(changeObj.origin == "setValue") {
+        this.showVotingLinkWhenAvailable();
         return;
       } else {
         this.saveInput(this.mde[questionNr].value(), questionNr);

--- a/html/js/dwa-additions.js
+++ b/html/js/dwa-additions.js
@@ -527,7 +527,7 @@ class QnAForm {  // similar to LongExercise, but having multiple fields
 
   createVotingLink(){
     const url = `/qna-results.html?group=${encodeURIComponent(window.userInfo.group)}&qna=${encodeURIComponent(this.qnaId)}`
-    this.element.innerHTML += `<div class="dwa-addition voting-section"><p>Omdat je het minimaal aantal vragen hebt ingevuld kun je stemmen op vragen gesteld door medestudenten. De docent gebruikt deze stemmen om te bepalen wat de belangrijkste vragen zijn.</p><a href="${url}">Stem op de ingediende vragen</a>&nbsp;&nbsp;&nbsp;<a target="_blank" href="${url}">(in nieuw tabblad)</a>`
+    this.element.innerHTML += `<div class="dwa-addition voting-section hidden"><p>Omdat je het minimaal aantal vragen hebt ingevuld kun je stemmen op vragen gesteld door medestudenten. De docent gebruikt deze stemmen om te bepalen wat de belangrijkste vragen zijn.</p><a href="${url}">Stem op de ingediende vragen</a>&nbsp;&nbsp;&nbsp;<a target="_blank" href="${url}">(in nieuw tabblad)</a>`
   }
 
   showUI() {


### PR DESCRIPTION
Adds the option to vote on QnA questions provided by other students:

![image](https://user-images.githubusercontent.com/18325396/93001829-0d634180-f532-11ea-8508-2fca444b6f2d.png)

The section that describes to vote when a student has provided enough questions:
![image](https://user-images.githubusercontent.com/18325396/93001840-32f04b00-f532-11ea-9d25-045f17f221a9.png)


Live Demo:
**QnA:** https://dwa-test-706c9.firebaseapp.com/qna_cwd_4.2.html
**Voting page:** https://dwa-test-706c9.firebaseapp.com/qna-results.html?group=B&qna=cwd-4-2

Good to know:

- The voting logic developed specifically for staff members has been refactord to this generic version where anyone can vote.
- The firebase rules have been modified to make them more flexible because students now need to be able to retrieve all users to show the overview.
- Several methods have been put in place to prevent voter spoofing. Specific rules were added to allow a student to add him/herself to the upvoters objects of a question of another student. The voter does not have write access to the question.
